### PR TITLE
Set API key via env; update project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-build/*
-dist/*
-dom.egg-info/*
-config/domainr.ini
+build/
+dist/
+dom.egg-info/
 *.pyc
+
+# IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -2,40 +2,59 @@ dom
 ===
 
 An easy-to-use command line utility for checking domain name
-availability using [Domainr's JSON API v1](https://domainr.readme.io/v1.0/docs).
+availability using [Domainr's JSON API](https://market.mashape.com/domainr/domainr V2 API).
 
-![](http://i.imgur.com/oijaG.png)
+
+![Example of dom in action](http://i.imgur.com/oijaG.png)
+
+Setup requires two things:
+
+1. Installing dom
+2. Obtaining an API key
+
 
 Installation
 ------------
 
-Previously, you could install and use the package through `pip` by simply running:
+The simplest method is to install the package through `pip` by running:
 
     pip install dom
 
-At the moment, it will throw a KeyError because the API is deprecated and doesn't handle the return value correctly. To use an updated version, perform the following steps:
+Alternatively, you can install from source:
 
 1. Clone the repo:
 
     `$ git clone git@github.com:zachwill/dom.git`  
     `$ cd dom`
 
-2. Do one of the following:
-    
-    a. Get a Mashape Domainr API key from [here](https://market.mashape.com/domainr/domainr)
-    **Note:** While it is free up to 10,000 calls/mo., you are required to submit a valid credit card to cover 
-    any requests over the free limit.
-
-    b. Contact Domainr at `partners@domainr.com` to get a personal use client ID, as detailed [here](https://github.com/UltrosBot/Ultros-contrib/issues/29#issuecomment-135285713)
-
-4. Insert either the Mashape API key or the Client ID into the `domainr/domainr.ini` file as documented in the file comments.
-
-5. Run the following command to install:
+2. Run the following command to install:
 	`python setup.py install`
 
-6. To avoid accidentally publishing your API key, you can also perform the following command:
-	`git update-index --assume-unchanged domainr/domainr.ini`
-This will tell git to not expect any changes on your end and to ignore it when pushing changes.
+
+Get an API key for Domainr
+--------------------------
+
+Due to abuse of their API, Domainr now requires an API key for each user. This key can be obtained through one
+of the following ways:
+
+1. Get a Mashape Domainr API key from the [Mashape Market](https://market.mashape.com/domainr/domainr)
+    **Note:** While it is free up to 10,000 calls/mo., you are required to submit a valid credit card to cover 
+    any requests over the free limit.
+2. Contact Domainr at `partners@domainr.com` to get a personal use client ID, as detailed 
+   [here](https://github.com/UltrosBot/Ultros-contrib/issues/29#issuecomment-135285713)
+3. Insert either the Mashape API key or the Client ID into your local environment:
+```
+$ export DOMAINR_MASHAPE_KEY={your-mashape-key}
+```
+or
+```
+$ export DOMAINR_CLIENT_ID={your-client-id}
+```
+
+You can do this manually everytime before running dom, or you can search for how to do this on login. Digital Ocean
+has an excellent guide here: [How To Read and Set Environmental and Shell Variables on a Linux VPS](https://www.digitalocean.com/community/tutorials/how-to-read-and-set-environmental-and-shell-variables-on-a-linux-vps).
+
+Note that in the event that both keys are present, dom will default to using the Mashape Key.
 
 
 Optional Flags
@@ -65,6 +84,14 @@ dom --available zachwill
 ✓  zachwill.co
 ✓  zachwill.io
 ✓  zachwill.me
+```
+
+The `--no-suggest` flag only check the exact domain names that are in query:
+
+```
+dom --no-suggest zachwill.com
+
+✗  zachwill.com
 ```
 
 And, the `--tld` flag only shows top-level domains:

--- a/domainr/core.py
+++ b/domainr/core.py
@@ -3,8 +3,7 @@ Core functionality for Domainr.
 """
 
 from argparse import ArgumentParser
-import configparser
-import pkg_resources
+import os
 import requests
 import simplejson as json
 import sys
@@ -14,99 +13,117 @@ from termcolor import colored
 class Domain(object):
     """Main class for interacting with the domains API."""
 
-    def environment(self):
+    def __init__(self):
+        """Instantiate class, grab credentials from env if available"""
+        if os.environ.get('DOMAINR_MASHAPE_KEY'):
+            self.api_key = os.environ.get('DOMAINR_MASHAPE_KEY')
+            self.api_key_name = 'mashape-key'
+            self.api_endpoint = "https://domainr.p.mashape.com"
+        elif os.environ.get('DOMAINR_CLIENT_ID'):
+            self.api_key = os.environ.get('DOMAINR_CLIENT_ID')
+            self.api_key_name = 'client_id'
+            self.api_endpoint = "https://api.domainr.com"
+        else:
+            sys.exit("Error: No API key found in environment\n" +
+                     "For more information, see README")
+
+    @staticmethod
+    def environment():
         """Parse any command line arguments."""
+        parser = Domain._get_argparser()
+        args = parser.parse_args()
+        return args
+
+    def search(self, env):
+        """Use domainr to get information about domain names."""
+        query = " ".join(env.query)
+        params = {'query': query, self.api_key_name: self.api_key}
+
+        url = self.api_endpoint + "/v2/search"
+
+        json_data = requests.get(url, params=params)
+
+        if not json_data.status_code == 200:
+            return "Error: Status {0}; Response: {1}".format(json_data.status_code, json_data.content)
+        data = self.parse_search(json_data.content, env)
+        if not data:
+            return "No results found\n"
+        else:
+            return data
+
+    def status(self, env):
+        """Use domainr to get information about domain names."""
+        url = self.api_endpoint + "/v2/status"
+        query = ",".join(env.query)
+        json_data = requests.get(url, params={'domain': query, self.api_key_name: self.api_key})
+        data = Domain.parse_status(json_data.content, env)
+        return data
+
+    @staticmethod
+    def parse_search(content, env):
+        """Parse the relevant data from JSON."""
+        data = json.loads(content)
+        results = data['results']
+        if env.tld:
+            output = [result['domain'] for result in results if Domain._tld_check(result['domain'])]
+        else:
+            output = [result['domain'] for result in results]
+        output.sort()
+        return output
+
+    @staticmethod
+    def parse_status(content, env):
+        """Parse the relevant data from JSON."""
+        data = json.loads(content)
+        output = []
+        status = data['status']
+        for s in status:
+            name = s['domain']
+            status = s['status']
+            if status.endswith('inactive'):
+                name = colored(name, 'blue', attrs=['bold'])
+                symbol = colored(u"\u2713", 'green')
+                if env.ascii:
+                    symbol = colored('A', 'green')
+            else:
+                # The available flag should skip these.
+                if env.available:
+                    continue
+                symbol = colored(u"\u2717", 'red')
+                if env.ascii:
+                    symbol = colored('X', 'red')
+            string = "%s  %s" % (symbol, name)
+            output.append(string)
+        output.sort()
+        return output
+
+    @staticmethod
+    def _tld_check(name):
+        """Make sure we're dealing with a top-level domain."""
+        if name.endswith(".com") or name.endswith(".net") or name.endswith(".org"):
+            return True
+        return False
+
+    @staticmethod
+    def _get_argparser():
+        """Helper function to get argument parser"""
         parser = ArgumentParser()
         parser.add_argument('query', type=str, nargs='+',
-                            help="Your domain name query.")
-        parser.add_argument('-i', '--info', action='store_true',
-                            help="Get information for a domain name.")
+                            help="Your domain name query. With --no-suggest, must give full domain in query.")
         parser.add_argument('--ascii', action='store_true',
                             help="Use ASCII characters for domain availability.")
         parser.add_argument('--available', action='store_true',
                             help="Only show domain names that are currently available.")
         parser.add_argument('--tld', action='store_true',
                             help="Only check for top-level domains.")
-        args = parser.parse_args()
-        return args
-
-    def search(self, env):
-        """Use domainr to get information about domain names."""
-        
-        query = " ".join(env.query)
-        params = {'q': query}
-
-        # Try and get the API key from the config file
-        config = configparser.ConfigParser()
-        configFilename = pkg_resources.resource_filename('domainr', 'domainr.ini')
-        config.read(configFilename)
-    
-        if config['Default']['mashape-key']:
-            params['mashape-key'] = config['Default']['mashape-key']
-            url = "https://domainr.p.mashape.com"
-        elif config['Default']['client_id']:
-            params['client_id'] = config['Default']['client_id']
-            url = "https://api.domainr.com"
-        else:
-            sys.exit("Error: No API key provided in config file at:\n"
-                + "{0}\n".format(configFilename) 
-                + "See the README for more info")
-
-        if env.info:
-            url += "/v1/info"
-        else:
-            url += "/v1/search"
-
-        json_data = requests.get(url, params=params)
-        # print(json_data.url)
-
-        if not json_data.status_code == 200:
-            return "Error: Status {0}; Response: {1}".format(json_data.status_code, json_data._content)
-        data = self.parse(json_data.content, env)
-        if not data:
-            return "No results found\n"
-        else:
-            return data
-
-    def parse(self, content, env):
-        """Parse the relevant data from JSON."""
-        data = json.loads(content)
-        if not env.info:
-            # Then we're dealing with a domain name search.
-            output = []
-            results = data['results']
-            for domain in results:
-                name = domain['domain']
-                availability = domain['availability']
-                if availability == 'available':
-                    name = colored(name, 'blue', attrs=['bold'])
-                    symbol = colored(u"\u2713", 'green')
-                    if env.ascii:
-                        symbol = colored('A', 'green')
-                else:
-                    symbol = colored(u"\u2717", 'red')
-                    if env.ascii:
-                        symbol = colored('X', 'red')
-                    # The available flag should skip these.
-                    if env.available:
-                        continue
-                string = "%s  %s" % (symbol, name)
-                # Now, a few sanity checks before we add it to the output.
-                if env.tld:
-                    if self._tld_check(domain['domain']):
-                        output.append(string)
-                else:
-                    output.append(string)
-            return '\n'.join(output)
-        # Then the user wants information on a domain name.
-        return data
-
-    def _tld_check(self, name):
-        """Make sure we're dealing with a top-level domain."""
-        if name.endswith(".com") or name.endswith(".net") or name.endswith(".org"):
-            return True
-        return False
+        parser.add_argument('--no-suggest', action='store_true',
+                            help="No suggested domains.")
+        return parser
 
     def main(self):
         args = self.environment()
-        print(self.search(args))
+        if not args.no_suggest:
+            args.query = self.search(args)
+        status = self.status(args)
+        print('\n'.join(status))
+

--- a/domainr/domainr.ini
+++ b/domainr/domainr.ini
@@ -1,9 +1,0 @@
-[Default]
-# Get an id from mashape for the domainr API
-# Example: mashape-key=abcdefgijh1232340983498
-mashape-key=
-
-# Alternatively, get a client_id by contacting partners@domainr.com
-# (https://github.com/UltrosBot/Ultros-contrib/issues/29#issuecomment-135285713)
-# Example: client_id=mashape-thisisnotarealclientid
-client_id=

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-configparser
-mock
 requests
 simplejson
 termcolor

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="dom",
-    version="0.7",
+    version="0.8",
     description="An easy-to-use command line utility for domain name lookups.",
     author="Zach Williams",
     author_email="hey@zachwill.com",
@@ -20,6 +20,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Utilities'
@@ -27,15 +28,10 @@ setup(
     packages=[
         "domainr"
     ],
-    package_data = {
-        'domainr': ['domainr.ini']
-    },
     scripts=[
         "dom"
     ],
-    tests_require=['mock'],
     install_requires=[
-        "configparser",
         "requests",
         "simplejson",
         "termcolor"

--- a/test.py
+++ b/test.py
@@ -2,59 +2,35 @@
 
 import sys
 import unittest
-import simplejson as json
-from argparse import Namespace
-from mock import MagicMock
 from domainr import Domain
 
-content = '{"query":"google","results":[{"domain":"google","host":"","subdomain":"google","path":"","availability":"tld","register_url":"https://domainr.com/google/register"},{"domain":"google.com","host":"","subdomain":"google.com","path":"","availability":"taken","register_url":"https://domainr.com/google.com/register"},{"domain":"google.net","host":"","subdomain":"google.net","path":"","availability":"taken","register_url":"https://domainr.com/google.net/register"},{"domain":"google.org","host":"","subdomain":"google.org","path":"","availability":"taken","register_url":"https://domainr.com/google.org/register"},{"domain":"google.co","host":"","subdomain":"google.co","path":"","availability":"taken","register_url":"https://domainr.com/google.co/register"},{"domain":"goo.gle","host":"","subdomain":"goo.gle","path":"","availability":"unavailable","register_url":"https://domainr.com/goo.gle/register"},{"domain":"goo.gl","host":"","subdomain":"goo.gl","path":"/e","availability":"unavailable","register_url":"https://domainr.com/goo.gl/register"},{"domain":"go.gle","host":"","subdomain":"go.gle","path":"","availability":"unavailable","register_url":"https://domainr.com/go.gle/register"},{"domain":"goog","host":"","subdomain":"goog","path":"/le","availability":"tld","register_url":"https://domainr.com/goog/register"},{"domain":"go.gl","host":"","subdomain":"go.gl","path":"/e","availability":"unavailable","register_url":"https://domainr.com/go.gl/register"},{"domain":"g.gle","host":"","subdomain":"g.gle","path":"","availability":"unavailable","register_url":"https://domainr.com/g.gle/register"},{"domain":"goo","host":"","subdomain":"goo","path":"/gle","availability":"tld","register_url":"https://domainr.com/goo/register"},{"domain":"g.gl","host":"","subdomain":"g.gl","path":"/e","availability":"unavailable","register_url":"https://domainr.com/g.gl/register"},{"domain":"gg","host":"","subdomain":"gg","path":"/le","availability":"tld","register_url":"https://domainr.com/gg/register"}]}'
-parse_false_response = u'\x1b[31m\u2717\x1b[0m  google\n\x1b[31m\u2717\x1b[0m  google.com\n\x1b[31m\u2717\x1b[0m  google.net\n\x1b[31m\u2717\x1b[0m  google.org\n\x1b[31m\u2717\x1b[0m  google.co\n\x1b[31m\u2717\x1b[0m  goo.gle\n\x1b[31m\u2717\x1b[0m  goo.gl\n\x1b[31m\u2717\x1b[0m  go.gle\n\x1b[31m\u2717\x1b[0m  goog\n\x1b[31m\u2717\x1b[0m  go.gl\n\x1b[31m\u2717\x1b[0m  g.gle\n\x1b[31m\u2717\x1b[0m  goo\n\x1b[31m\u2717\x1b[0m  g.gl\n\x1b[31m\u2717\x1b[0m  gg'
-info_data = {'domain': 'google', 'whois_url': 'https://domainr.com/google/whois', 'subregistration_permitted': False, 'register_url': 'https://domainr.com/google/register', 'tld': {'domain': 'google', 'wikipedia_url': 'https://domainr.com/google/wikipedia', 'iana_url': 'https://domainr.com/google/iana'}, 'registrars': [], 'subdomains': [], 'host': '', 'path': '', 'www_url': 'https://domainr.com/google/www', 'query': 'google', 'subdomain': 'google', 'domain_idna': 'google', 'availability': 'tld'}
+
+search_result = ['goo', 'goo.gl', 'goo.gle', 'goog', 'google', 'google.com', 'google.net', 'google.org', 'google.us']
+status_result = ['\x1b[31m✗\x1b[0m  goo', '\x1b[31m✗\x1b[0m  goo.gl', '\x1b[31m✗\x1b[0m  goo.gle',
+                 '\x1b[31m✗\x1b[0m  goog', '\x1b[31m✗\x1b[0m  google', '\x1b[31m✗\x1b[0m  google.com',
+                 '\x1b[31m✗\x1b[0m  google.net', '\x1b[31m✗\x1b[0m  google.org', '\x1b[31m✗\x1b[0m  google.us']
+
 
 class TestDomain(unittest.TestCase):
 
-
     def setUp(self):
-        sys.argv = ['core.py','google']
-
+        sys.argv = ['core.py', 'google']
 
     def tearDown(self):
         sys.argv = []
 
-
-    def test_parse_info_false(self):
+    def test_search(self):
+        env = Domain._get_argparser().parse_args()
         domain = Domain()
-        result = domain.parse(content, False)
-        self.assertEquals(result, parse_false_response)
+        result = domain.search(env)
+        self.assertEquals(result, search_result)
 
-
-    def test_parse_info_true(self):
+    def test_status(self):
+        env = Domain._get_argparser().parse_args()
+        env.query = search_result
         domain = Domain()
-        result = domain.parse(content, True)
-        parse_true_response = json.loads(content)
-        self.assertEquals(result, parse_true_response)
-
-
-    def test_search_false(self):
-        environment = Namespace(info=False, query=['google'])
-        domain = Domain()
-        result = domain.search(environment)
-        self.assertEquals(result, parse_false_response)
-
-
-    def test_search_true(self):
-        environment = Namespace(info=True, query=['google'])
-        domain = Domain()
-        result = domain.search(environment)
-        self.assertEquals(result, info_data)
-
-
-    def test_flow(self):
-        mock = MagicMock(spec=Domain)
-        mock.main()
-        mock.environment.assert_called_once()
-        mock.search.assert_called_once()
-        mock.parse.assert_called_once
+        result = domain.status(env)
+        self.assertEquals(result, status_result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a big commit, but merges the good idea from @alexzhangs to use the environment variables to pass the API key to dom as opposed to what I originally did with reading them from a config file. This allows for the package to be installed via pip again. Furthermore, takes @alexzhangs' updates to use the v2 API as well.

This commit also updates the tests, since they didn't seem to currently be working anyways. The setup.py, requirements.txt, and README.md files are also updated to reflect these changes.

@zachwill I'll let this sit for a bit so you can check it out, but unless there are any problems presented, I'll merge it in since you granted me access earlier today.
